### PR TITLE
Copy MP3s instead of move; preserve metadata, do not overwrite

### DIFF
--- a/flatten-directories.sh
+++ b/flatten-directories.sh
@@ -56,8 +56,8 @@ find "$SOURCE_ROOT" -mindepth 2 -type f -iname "*.mp3" -print0 | while IFS= read
     ((counter++))
   done
 
-  # Copy the file to the flat destination (preserve metadata, do not overwrite)
-  cp -n -p "$filepath" "$target_file"
+  # Copy the file to the flat destination (preserve mode and timestamps; avoid ownership; allow overwrite; CoW if supported)
+  cp --preserve=mode,timestamps --reflink=auto "$filepath" "$target_file"
   echo "Copied: $filepath -> $target_file"
 done
 

--- a/flatten-directories.sh
+++ b/flatten-directories.sh
@@ -56,9 +56,9 @@ find "$SOURCE_ROOT" -mindepth 2 -type f -iname "*.mp3" -print0 | while IFS= read
     ((counter++))
   done
 
-  # Move the file to the flat destination
-  mv "$filepath" "$target_file"
-  echo "Moved: $filepath -> $target_file"
+  # Copy the file to the flat destination (preserve metadata, do not overwrite)
+  cp -n -p "$filepath" "$target_file"
+  echo "Copied: $filepath -> $target_file"
 done
 
-echo "Flattening complete. Files moved to: $DEST_DIR"
+echo "Flattening complete. Files copied to: $DEST_DIR"


### PR DESCRIPTION
- Replace mv with cp -n -p to copy files into flat destination
- Preserve permissions/timestamps and skip existing target files
- Update log messages to reflect copying
- Keep originals intact to avoid accidental data loss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * flatten-directories now copies files instead of moving them, making the operation non-destructive.
  * Copying preserves original timestamps and permissions, and it won’t overwrite existing files.
  * Updated logs clearly indicate copy actions and provide an accurate summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->