### PR TITLE
Add PowerShell script to copy M3U playlist to destination

### DIFF
--- a/copy-playlist.ps1
+++ b/copy-playlist.ps1
@@ -1,88 +1,206 @@
-# Set the source directory and destination folder
-$src = 'C:\Users\User\Music\mp3\result'
-$dst = 'D:\music'
-$m3uFile = 'C:\path\to\your\playlist.m3u'  # Path to your M3U file
+<# 
+.SYNOPSIS
+  Copy tracks referenced by an M3U/M3U8 playlist to a destination folder.
 
-# Create destination directory if it doesn't exist
-if (!(Test-Path $dst)) {
-    New-Item -ItemType Directory -Path $dst | Out-Null
+.DESCRIPTION
+  Reads a playlist file (.m3u/.m3u8), resolves each entry (absolute or relative to the playlist),
+  and copies files to the destination. If -SourceRoot is provided and a file resides under it,
+  the script preserves the relative subpath under Destination; otherwise it copies as a flat filename.
+
+  Existing files are only overwritten if the source is newer (unless -NoClobber is used).
+  Supports -WhatIf/-Confirm and -Verbose via CmdletBinding/ShouldProcess.
+
+.PARAMETER PlaylistPath
+  Full path to the M3U/M3U8 file to read.
+
+.PARAMETER Destination
+  Destination root folder where files will be copied. Created if it doesn't exist.
+
+.PARAMETER SourceRoot
+  Optional source root to preserve relative paths. If a source file's path starts with this root
+  (case-insensitive), its subpath is preserved under Destination. Otherwise, only the filename is used.
+
+.PARAMETER Encoding
+  Text encoding used when reading the playlist. Defaults to UTF8.
+
+.PARAMETER NoClobber
+  If set, never overwrite an existing destination file (skips regardless of timestamps).
+
+.EXAMPLE
+  .\copy-playlist.ps1 -PlaylistPath 'C:\Playlists\gym.m3u' -Destination 'E:\Music'
+
+.EXAMPLE
+  .\copy-playlist.ps1 -PlaylistPath 'C:\Playlists\gym.m3u' -Destination 'E:\Music' -SourceRoot 'C:\Users\User\Music\mp3'
+
+.EXAMPLE
+  .\copy-playlist.ps1 -PlaylistPath 'C:\Playlists\gym.m3u' -Destination 'E:\Music' -WhatIf -Verbose
+
+.NOTES
+  Requires PowerShell 5+ (or PowerShell 7+). Uses ShouldProcess to honor -WhatIf/-Confirm.
+#>
+
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+param(
+  # Full path to the .m3u/.m3u8 file
+  [Parameter(Mandatory, Position = 0)]
+  [ValidateNotNullOrEmpty()]
+  [string]$PlaylistPath,
+
+  # Destination root where tracks will be copied
+  [Parameter(Mandatory, Position = 1)]
+  [ValidateNotNullOrEmpty()]
+  [string]$Destination,
+
+  # Optional source root used to preserve relative directory structure if a track lies under this root
+  [Parameter(Position = 2)]
+  [string]$SourceRoot,
+
+  # Encoding used to read the playlist
+  [ValidateSet('UTF8','UTF8BOM','ASCII','Unicode','UTF7','UTF32','BigEndianUnicode','Default','OEM')]
+  [string]$Encoding = 'UTF8',
+
+  # If set, skip when destination exists regardless of timestamps
+  [switch]$NoClobber
+)
+
+Set-StrictMode -Version Latest
+
+# Resolve/validate paths
+try {
+  $PlaylistPath = (Resolve-Path -LiteralPath $PlaylistPath -ErrorAction Stop).Path
+} catch {
+  throw "Playlist file not found: $PlaylistPath"
 }
 
-# Read M3U file and extract file paths
+# Normalize Destination; create if missing
+try {
+  if (-not (Test-Path -LiteralPath $Destination)) {
+    Write-Verbose "Creating destination directory: $Destination"
+    New-Item -ItemType Directory -Path $Destination -Force -ErrorAction Stop | Out-Null
+  }
+  $Destination = (Resolve-Path -LiteralPath $Destination -ErrorAction Stop).Path
+} catch {
+  throw "Unable to prepare destination '$Destination': $($_.Exception.Message)"
+}
+
+# Normalize SourceRoot if provided
+$NormalizedSourceRoot = $null
+if ($SourceRoot) {
+  try {
+    if (Test-Path -LiteralPath $SourceRoot) {
+      $NormalizedSourceRoot = (Resolve-Path -LiteralPath $SourceRoot -ErrorAction Stop).Path
+    } else {
+      # Allow a not-yet-existing root; use as provided for StartsWith compare
+      $NormalizedSourceRoot = $SourceRoot
+    }
+  } catch {
+    $NormalizedSourceRoot = $SourceRoot
+  }
+}
+
+# Read playlist lines
+try {
+  $lines = Get-Content -LiteralPath $PlaylistPath -Encoding $Encoding -ErrorAction Stop
+} catch {
+  throw "Failed to read playlist '$PlaylistPath': $($_.Exception.Message)"
+}
+
+# Filter out comments/blank lines
 $playlistFiles = @()
-if (Test-Path $m3uFile) {
-    $playlistContent = Get-Content $m3uFile -Encoding UTF8
-    foreach ($line in $playlistContent) {
-        # Skip comments and empty lines
-        if ($line -notmatch '^#' -and $line.Trim() -ne '') {
-            $playlistFiles += $line.Trim()
-        }
-    }
-} else {
-    Write-Host "M3U file not found: $m3uFile"
-    exit 1
+foreach ($line in $lines) {
+  $t = ($line ?? '').Trim()
+  if ($t.Length -gt 0 -and -not $t.StartsWith('#')) {
+    $playlistFiles += $t
+  }
 }
 
-# Process each file from the playlist
-foreach ($playlistFile in $playlistFiles) {
-    # Handle relative paths in M3U (relative to M3U file location)
-    if ([System.IO.Path]::IsPathRooted($playlistFile)) {
-        $sourceFile = $playlistFile
-    } else {
-        $m3uDir = [System.IO.Path]::GetDirectoryName($m3uFile)
-        $sourceFile = Join-Path $m3uDir $playlistFile
-    }
-    
-    # Check if the file exists
-    if (!(Test-Path $sourceFile)) {
-        Write-Host "File not found: $sourceFile"
-        continue
-    }
-    
-    # Get file info
-    $file = Get-Item $sourceFile
-    
-    # Create relative path from source directory
-    if ($file.FullName.StartsWith($src, [System.StringComparison]::OrdinalIgnoreCase)) {
-        $relative = $file.FullName.Substring($src.Length).TrimStart('\')
-    } else {
-        # If file is outside source directory, use filename only
+$processed = 0
+$copied    = 0
+$updated   = 0
+$skipped   = 0
+$errors    = 0
+
+$playlistDir = Split-Path -LiteralPath $PlaylistPath -Parent
+
+foreach ($entry in $playlistFiles) {
+  # Resolve absolute vs relative entries
+  if ([System.IO.Path]::IsPathRooted($entry)) {
+    $sourceFile = $entry
+  } else {
+    $sourceFile = Join-Path -Path $playlistDir -ChildPath $entry
+  }
+
+  if (-not (Test-Path -LiteralPath $sourceFile)) {
+    Write-Warning "File not found: $sourceFile"
+    $skipped++
+    continue
+  }
+
+  $file = Get-Item -LiteralPath $sourceFile
+
+  # Determine relative path under Destination
+  $relative = $file.Name
+  if ($NormalizedSourceRoot) {
+    # Case-insensitive StartsWith
+    if ($file.FullName.StartsWith($NormalizedSourceRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+      $relative = $file.FullName.Substring($NormalizedSourceRoot.Length).TrimStart('\','/')
+      if ([string]::IsNullOrWhiteSpace($relative)) {
         $relative = $file.Name
+      }
     }
-    
-    $target = Join-Path $dst $relative
-    
-    # Create the directory structure if needed
-    $targetDir = Split-Path $target
-    if (!(Test-Path $targetDir)) {
-        New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
-    }
+  }
 
+  $target = Join-Path -Path $Destination -ChildPath $relative
+  $targetDir = Split-Path -Path $target -Parent
+
+  # Ensure target directory exists
+  if (-not (Test-Path -LiteralPath $targetDir)) {
     try {
-        if (Test-Path -Path $target) {
-            # Check if source file is newer than destination
-            $srcLastModified = $file.LastWriteTime
-            $dstLastModified = (Get-Item $target).LastWriteTime
-
-            if ($srcLastModified -gt $dstLastModified) {
-                Copy-Item -Path $file.FullName -Destination $target -Force
-                Write-Host "Updated (newer): ${relative}"
-            } else {
-                Write-Host "Skipped (same or older): ${relative}"
-            }
-        } else {
-            # File doesn't exist in destination, copy it
-            Copy-Item -Path $file.FullName -Destination $target -Force
-            Write-Host "Copied (new): ${relative}"
-        }
+      Write-Verbose "Creating directory: $targetDir"
+      New-Item -ItemType Directory -Path $targetDir -Force -ErrorAction Stop | Out-Null
     } catch {
-        if ($_.Exception.Message -match "There is not enough space") {
-            Write-Host "No more space left copying: ${relative}"
-            break
-        } else {
-            Write-Host "Error copying ${relative}: $($_.Exception.Message)"
-        }
+      Write-Warning "Unable to create directory '$targetDir': $($_.Exception.Message)"
+      $errors++
+      continue
     }
+  }
+
+  try {
+    if (Test-Path -LiteralPath $target) {
+      if ($NoClobber) {
+        Write-Verbose "Skipping existing (NoClobber): $relative"
+        $skipped++
+      } else {
+        $dstItem = Get-Item -LiteralPath $target
+        if ($file.LastWriteTime -gt $dstItem.LastWriteTime) {
+          if ($PSCmdlet.ShouldProcess($target, "Update (newer) from '$($file.FullName)'")) {
+            Copy-Item -LiteralPath $file.FullName -Destination $target -Force
+            Write-Host "Updated: $relative"
+            $updated++
+          }
+        } else {
+          Write-Host "Skipped (same or older): $relative"
+          $skipped++
+        }
+      }
+    } else {
+      if ($PSCmdlet.ShouldProcess($target, "Copy (new) from '$($file.FullName)'")) {
+        Copy-Item -LiteralPath $file.FullName -Destination $target -Force
+        Write-Host "Copied: $relative"
+        $copied++
+      }
+    }
+  } catch {
+    $errors++
+    if ($_.Exception.Message -match "There is not enough space") {
+      Write-Host "No more space left copying: $relative"
+      break
+    } else {
+      Write-Warning "Error copying $relative: $($_.Exception.Message)"
+    }
+  }
+
+  $processed++
 }
 
-Write-Host "Playlist copy completed. Processed $($playlistFiles.Count) files."
+Write-Host "Playlist copy completed. Processed: $processed. Copied: $copied. Updated: $updated. Skipped: $skipped. Errors: $errors."


### PR DESCRIPTION
Introduce copy-playlist.ps1 to sync tracks from an M3U playlist to a target folder.
- Supports absolute and relative paths (relative to the M3U file)
- Preserves directory structure relative to a source root, else uses filename
- Creates missing directories and copies only new/updated files (timestamp check)
- Logs actions and handles low-disk-space and other copy errors

This enables efficient playlist-based syncing to an external drive without redundant copies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a PowerShell tool to copy files referenced by an M3U/M3U8 playlist to a destination.
  * Supports absolute and relative playlist entries; preserves directory structure when entries fall under a specified source root.
  * Creates destination folders as needed and overwrites only when the source is newer (or skips with NoClobber).
  * Provides per-file statuses (Copied, Updated, Skipped) and a final summary; handles missing files and low-disk-space errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->